### PR TITLE
Add update_port_policy role

### DIFF
--- a/roles/update_ucs_fi_port_policy/README.md
+++ b/roles/update_ucs_fi_port_policy/README.md
@@ -1,0 +1,82 @@
+# Update Fabric Interconnect Port Policy
+
+## Overview
+
+Each fabric interconnect has a set of ports in a fixed port module that you can configure as either server ports or uplink Ethernet ports. These ports are not reserved and they cannot be used by a Cisco UCS instance until you configure them. 
+
+To extend an existing Cisco UCS domain with additional Cisco UCS C-Series servers or Cisco UCS X-Series compute nodes new ports need to be configured as server ports. They will handle data traffic between the fabric interconnect and the adapter cards.
+
+## Features
+
+- Configure ports as server ports on port policy via Intersight.
+- Supports breakout ports.
+- Supports multiple port policies and domain profiles.
+
+## Requirements
+
+* Ansible v2.15.0 or newer
+* Python 3.7 or newer (Older Python versions are no longer supported with this collection)
+* The [Cisco Intersight](https://docs.ansible.com/ansible/latest/collections/cisco/intersight/index.html) Ansible collection is installed.
+* Intersight user account with valid credentials and Cisco Intersight API private key and key ID.
+
+## Role Variables
+
+| Variable                                                | Description                                                                             | Default                         |
+|---------------------------------------------------------|-----------------------------------------------------------------------------------------|---------------------------------|
+| `update_ucs_fi_port_policy_api_private_key`             | Path to Cisco Intersight API private key.                                               |                                 |
+| `update_ucs_fi_port_policy_api_key_id`                  | Cisco Intersight API key ID.                                                            |                                 |
+| `update_ucs_fi_port_policy_api_uri`                     | Cisco Intersight API URI.                                                               | <https://intersight.com/api/v1> |
+| `update_ucs_fi_port_policy_validate_certs`              | Validate SSL certificates (*false* for self-signed certificates)                        | true                            |
+| `update_ucs_fi_port_policy_port_id_list`                | Ports that will be configured as server in the selected policies.                       | **Required** (no default)       |
+| `update_ucs_fi_port_policy_slot_id_list`                | Slot ids that will be configured in the selected policies.                              | [1]                             |
+| `update_ucs_fi_port_policy_name_of_domain_profile_list` | List of UCS domain profiles names.                                                      | **Required** (no default)       |
+| `update_ucs_fi_port_policy_port_policy_list`            | List of port policy names.                                                              | **Required** (no default)       |
+| `update_ucs_fi_port_policy_breakout_option`             | Breakout option string. Chosen from: 'BreakoutEthernet10G' Or 'BreakoutEthernet25G'     |                                 |
+
+Notes:
+* If update_ucs_fi_port_policy_port_id_list is set, you must set update_ucs_fi_port_policy_breakout_option and vice versa.
+* The format of variable update_ucs_fi_port_policy_port_id_list can be breakout port id (e.g. 52/1) or regular port id (e.g. 5). But it can't be both in the same list.
+* Intersight handles the Domain profile internally as A and B, therefore a list is required even with a single domain profile visible in Intersight.
+* update_ucs_fi_port_policy_api_private_key variable definition can be declared optionally file, vault or .env based.
+
+## Example 1 (without breakout):
+
+```yaml
+    ---
+    - name: Update UCS Fabric Interconnect port role as server port
+      hosts: localhost
+      vars:
+        update_ucs_fi_port_policy_api_private_key: "{{ 'INTERSIGHT_API_PRIVATE_KEY'}}"
+        update_ucs_fi_port_policy_api_key_id: "{{ 'INTERSIGHT_API_KEY_ID' }}"
+        update_ucs_fi_port_policy_port_id_list: [5, 6, 7, 8]
+        update_ucs_fi_port_policy_port_policy_list: ["AC08-6454-A-Port-Policy", "AC08-6454-B-Port-Policy"]
+        update_ucs_fi_port_policy_name_of_domain_profile_list: ["AC08-6454-Domain-Profile-A", "AC08-6454-Domain-Profile-B"]
+      roles:
+        - update_ucs_fi_port_policy
+```
+
+## Example 2 (with breakout): 
+
+```yaml
+    - name: Update UCS Fabric Interconnect port role as server port - Breakout option
+      hosts: localhost
+      vars:
+        update_ucs_fi_port_policy_api_private_key: "{{ 'INTERSIGHT_API_PRIVATE_KEY' }}"
+        update_ucs_fi_port_policy_api_key_id: "{{ 'INTERSIGHT_API_KEY_ID' }}"
+        update_ucs_fi_port_policy_port_policy_list: ["AC08-6454-A-Port-Policy", "AC08-6454-B-Port-Policy"]
+        update_ucs_fi_port_policy_name_of_domain_profile_list: ["AC08-6454-Domain-Profile-A", "AC08-6454-Domain-Profile-B"]
+        update_ucs_fi_port_policy_aggregate_port_id_list: [52/1, 52/2]
+        update_ucs_fi_port_policy_breakout_option: "BreakoutEthernet25G"
+      roles:
+        - update_ucs_fi_port_policy    
+```
+
+The role test folder contains a validate_ports.yml file you can use to verify the ports are configured correctly. 
+In this case copy the yml file to the same folder as the example playbook and extend the playbook with the following lines:
+
+      tasks:
+        - name: Verify the ports got correctly configured as per policy
+          ansible.builtin.include_tasks: validate_ports.yml
+          loop: "{{ update_ucs_fi_port_policy_port_policy_list }}"
+          loop_control:
+            loop_var: policy_name

--- a/roles/update_ucs_fi_port_policy/defaults/main.yml
+++ b/roles/update_ucs_fi_port_policy/defaults/main.yml
@@ -1,0 +1,9 @@
+# defaults file for update_ucs_fi_port_policy
+update_ucs_fi_port_policy_related_operation: update
+
+# API authentication
+update_ucs_fi_port_policy_api_uri: 'https://intersight.com/api/v1'
+update_ucs_fi_port_policy_validate_certs: true
+
+# Functionality
+update_ucs_fi_port_policy_slot_id_list: [1]

--- a/roles/update_ucs_fi_port_policy/meta/main.yml
+++ b/roles/update_ucs_fi_port_policy/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/roles/update_ucs_fi_port_policy/meta/runtime.yml
+++ b/roles/update_ucs_fi_port_policy/meta/runtime.yml
@@ -1,0 +1,1 @@
+requires_ansible: '>=2.15.0'

--- a/roles/update_ucs_fi_port_policy/tasks/deploy_domain_profile.yml
+++ b/roles/update_ucs_fi_port_policy/tasks/deploy_domain_profile.yml
@@ -1,0 +1,32 @@
+---
+- name: Define anchor for Intersight API login info
+  ansible.builtin.set_fact:
+    api_info: &api_info
+      api_private_key: "{{ update_ucs_fi_port_policy_api_private_key | default(omit) }}"
+      api_key_id: "{{ update_ucs_fi_port_policy_api_key_id | default(omit) }}"
+      api_uri: "{{ update_ucs_fi_port_policy_api_uri | default(omit) }}"
+      validate_certs: "{{ update_ucs_fi_port_policy_validate_certs | default(omit) }}"
+
+- name: "Gather MOID from {{ domain_profile_name }}"
+  cisco.intersight.intersight_rest_api:
+    <<: *api_info
+    resource_path: /fabric/SwitchProfiles
+    query_params:
+      $filter: "Name eq '{{ domain_profile_name }}'"
+  register: domain_profile_res
+
+- name: Wait 5 seconds for port configuration to be applied.
+  ansible.builtin.pause:
+    seconds: 5
+
+- name: "Deploy {{ domain_profile_name }}"
+  cisco.intersight.intersight_rest_api:
+    <<: *api_info
+    resource_path: /fabric/SwitchProfiles/{{ domain_profile_res.api_response.Moid }}
+    update_method: "post"
+    api_body: {
+      "Action": "Deploy",
+      "ConfigContext": {
+        "ControlAction": "Deploy"
+      }
+    }

--- a/roles/update_ucs_fi_port_policy/tasks/main.yml
+++ b/roles/update_ucs_fi_port_policy/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+# tasks file for update_ucs_fi_port_policy
+- name: Update Fabric Interconnect ports with server role - Day 2 Operation
+  ansible.builtin.include_tasks: "{{ update_ucs_fi_port_policy_related_operation }}.yml"

--- a/roles/update_ucs_fi_port_policy/tasks/update.yml
+++ b/roles/update_ucs_fi_port_policy/tasks/update.yml
@@ -1,0 +1,43 @@
+---
+- name: Verify required variables are defined and not empty
+  ansible.builtin.fail:
+    msg: "{{ item }} is not defined or empty"
+  when: "vars[item] is not defined or (vars[item] | length == 0)"
+  loop:
+    - "update_ucs_fi_port_policy_port_id_list"
+    - "update_ucs_fi_port_policy_port_policy_list"
+    - "update_ucs_fi_port_policy_name_of_domain_profile_list"
+
+- name: Determine format type (with or without '/')
+  ansible.builtin.set_fact:
+    breakout_port_format: "{{ update_ucs_fi_port_policy_port_id_list | select('search', '^\\d+/\\d+$') | list | length > 0 }}"
+    regular_port_format: "{{ update_ucs_fi_port_policy_port_id_list | select('search', '^\\d+$') | list | length > 0 }}"
+
+- name: Fail if the list contains a mix of formats
+  ansible.builtin.fail:
+    msg: "Error: configure_server_ports_port_id_list must have only 'XX/YY' format or only port numbers, not both!"
+  when: breakout_port_format and regular_port_format
+
+- name: Verify dependency is met between variables
+  ansible.builtin.fail:
+    msg: "configure_server_ports_port_id_list has breakout option format and configure_server_ports_breakout_option is not defined
+     OR configure_server_ports_port_id_list has regular port number format and configure_server_ports_breakout_option is defined."
+  when: breakout_port_format is true and update_ucs_fi_port_policy_breakout_option is not defined
+    or breakout_port_format is false and update_ucs_fi_port_policy_breakout_option is defined
+
+- name: Verify configure_server_ports_breakout_option value is correct if defined.
+  ansible.builtin.fail:
+    msg: "configure_server_ports_breakout_option value is not correct. Please set it to BreakoutEthernet10G, BreakoutEthernet25G or remove it."
+  when: update_ucs_fi_port_policy_breakout_option is defined and update_ucs_fi_port_policy_breakout_option not in ['BreakoutEthernet10G', 'BreakoutEthernet25G']
+
+- name: Update port policies
+  ansible.builtin.include_tasks: update_port_policy.yml
+  loop: "{{ update_ucs_fi_port_policy_port_policy_list }}"
+  loop_control:
+    loop_var: policy_name
+
+- name: Deploy domain profiles
+  ansible.builtin.include_tasks: deploy_domain_profile.yml
+  loop: "{{ update_ucs_fi_port_policy_name_of_domain_profile_list }}"
+  loop_control:
+    loop_var: domain_profile_name

--- a/roles/update_ucs_fi_port_policy/tasks/update_port_policy.yml
+++ b/roles/update_ucs_fi_port_policy/tasks/update_port_policy.yml
@@ -1,0 +1,70 @@
+---
+- name: Define anchor for Intersight API login info
+  ansible.builtin.set_fact:
+    api_info: &api_info
+      api_private_key: "{{ update_ucs_fi_port_policy_api_private_key | default(omit) }}"
+      api_key_id: "{{ update_ucs_fi_port_policy_api_key_id | default(omit) }}"
+      api_uri: "{{ update_ucs_fi_port_policy_api_uri | default(omit) }}"
+      validate_certs: "{{ update_ucs_fi_port_policy_validate_certs | default(omit) }}"
+
+- name: "Get port policy {{ policy_name }}"
+  cisco.intersight.intersight_rest_api:
+    <<: *api_info
+    resource_path: /fabric/PortPolicies
+    query_params:
+      $filter: "Name eq '{{ policy_name }}'"
+  register: port_policy_res
+
+- name: "Configure ports in port policy {{ policy_name }}"
+  cisco.intersight.intersight_rest_api:
+    <<: *api_info
+    resource_path: /fabric/ServerRoles
+    api_body: "{{ {
+          'PortPolicy': port_policy_res.api_response.Moid,
+          'SlotId': item.0 | int,
+          'PortId': item.1 | int,
+          'Fec': 'Auto',
+          'AutoNegotiationDisabled': false
+        } | to_json }}"
+  loop: "{{ update_ucs_fi_port_policy_slot_id_list | product(update_ucs_fi_port_policy_port_id_list) | list }}"
+  register: port_configuring_res
+  when: regular_port_format is defined and regular_port_format
+
+- name: Extract aggregate ports and store unique values
+  ansible.builtin.set_fact:
+    aggregate_ports: "{{ update_ucs_fi_port_policy_port_id_list | map('split', '/') | map('first') | list | unique }}"
+  when: breakout_port_format is defined and breakout_port_format
+
+- name: "Configure breakout options in port policy {{ policy_name }}"
+  cisco.intersight.intersight_rest_api:
+    <<: *api_info
+    resource_path: /fabric/PortModes
+    api_body: "{{ {
+          'PortPolicy': port_policy_res.api_response.Moid,
+          'SlotId': item.0 | int,
+          'PortIdStart': item.1 | int,
+          'PortIdEnd': item.1 | int,
+          'CustomMode': update_ucs_fi_port_policy_breakout_option
+        } | to_json }}"
+  loop: "{{ update_ucs_fi_port_policy_slot_id_list | product(aggregate_ports) | list }}"
+  register: port_configuring_breakout_option_res
+  when: breakout_port_format is defined and breakout_port_format
+
+- name: "Configure ports with breakout ports in port policy {{ policy_name }}"
+  vars:
+    aggregate_port_id: "{{ item.1.split('/')[0] }}"
+    port_id: "{{ item.1.split('/')[1] }}"
+  cisco.intersight.intersight_rest_api:
+    <<: *api_info
+    resource_path: /fabric/ServerRoles
+    api_body: "{{ {
+          'PortPolicy': port_policy_res.api_response.Moid,
+          'SlotId': item.0 | int,
+          'PortId': port_id | int,
+          'AggregatePortId': aggregate_port_id | int,
+          'Fec': 'Auto',
+          'AutoNegotiationDisabled': false
+        } | to_json }}"
+  loop: "{{ update_ucs_fi_port_policy_slot_id_list | product(update_ucs_fi_port_policy_port_id_list) | list }}"
+  register: port_configuring_breakout_res
+  when: breakout_port_format is defined and breakout_port_format

--- a/roles/update_ucs_fi_port_policy/tests/inventory
+++ b/roles/update_ucs_fi_port_policy/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/update_ucs_fi_port_policy/tests/test.yml
+++ b/roles/update_ucs_fi_port_policy/tests/test.yml
@@ -1,0 +1,17 @@
+---
+- name: Test update UCS Fabric Interconnect port role as server port
+  hosts: localhost
+  vars:
+    update_ucs_fi_port_policy_api_private_key: "{{ 'INTERSIGHT_API_PRIVATE_KEY'}}"
+    update_ucs_fi_port_policy_api_key_id: "{{ 'INTERSIGHT_API_KEY_ID' }}"
+    update_ucs_fi_port_policy_port_id_list: [5, 6, 7, 8]
+    update_ucs_fi_port_policy_port_policy_list: ["AC08-6454-A-Port-Policy", "AC08-6454-B-Port-Policy"]
+    update_ucs_fi_port_policy_name_of_domain_profile_list: ["AC08-6454-Domain-Profile-A", "AC08-6454-Domain-Profile-B"]
+  roles:
+    - update_ucs_fi_port_policy
+  tasks:
+    - name: Validate that ports got correctly configured per policy
+      ansible.builtin.include_tasks: validate_ports.yml
+      loop: "{{ update_ucs_fi_port_policy_port_policy_list }}"
+      loop_control:
+        loop_var: policy_name

--- a/roles/update_ucs_fi_port_policy/tests/validate_ports.yml
+++ b/roles/update_ucs_fi_port_policy/tests/validate_ports.yml
@@ -1,0 +1,43 @@
+---
+- name: Define anchor for Intersight API login info
+  ansible.builtin.set_fact:
+    api_info: &api_info
+      api_private_key: "{{ update_ucs_fi_port_policy_api_private_key | default(omit) }}"
+      api_key_id: "{{ update_ucs_fi_port_policy_api_key_id | default(omit) }}"
+      api_uri: "{{ update_ucs_fi_port_policy_api_uri | default(omit) }}"
+      validate_certs: "{{ update_ucs_fi_port_policy_validate_certs | default(omit) }}"
+
+- name: "Get port policy {{ policy_name }}"
+  cisco.intersight.intersight_rest_api:
+    <<: *api_info
+    resource_path: /fabric/PortPolicies
+    query_params:
+      $filter: "Name eq '{{ policy_name }}'"
+  register: port_policy_res
+
+- name: "Ports in port policy {{ policy_name }}"
+  cisco.intersight.intersight_rest_api:
+    <<: *api_info
+    resource_path: /fabric/ServerRoles
+    query_params:
+      $filter: "PortPolicy.Moid eq '{{ port_policy_res.api_response.Moid }}'"
+    return_list: true
+  register: port_configuring_res
+
+- name: Assert that all ports are configured
+  vars:
+    all_port_ids: "{{ port_configuring_res.api_response | map(attribute='PortId') | list }}"
+  ansible.builtin.assert:
+    that:
+      - "{{ item }} in all_port_ids"
+  loop: "{{ update_ucs_fi_port_policy_port_id_list }}"
+  when: regular_port_format is defined and regular_port_format
+
+- name: Assert that all ports are Aggregate ports configured
+  vars:
+    all_aggr_port_ids: "{{ port_configuring_res.api_response | map(attribute='AggregatePortId') | list }}"
+  ansible.builtin.assert:
+    that:
+      - "{{ item }} in all_aggr_port_ids"
+  loop: "{{ aggregate_ports }}"
+  when: breakout_port_format is defined and breakout_port_format


### PR DESCRIPTION
configure_server_ports role configures server ports on selected FI via Intersight.
Can be used either to discover a new chassis (with the connected servers) or for the addition of standalone servers.